### PR TITLE
Feature/hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /.vscode
 *.dSYM
 *.exe
+.DS_Store
+test/unit_test/tempCodeRunnerFile.cpp

--- a/game/board.h
+++ b/game/board.h
@@ -5,9 +5,11 @@
 #include "../test/test.h"
 #include <array>
 #include <vector>
+#include <random>
 
 #define BOARD_SIZE 15
 #define STATIC_WALL &cells[0][0];
+#define NUM_PIECE_TYPES 4
 
 using CellArray = array<array<Cell, BOARD_SIZE + 2>, BOARD_SIZE + 2>;
 using MoveList = vector<Pos>;
@@ -19,12 +21,19 @@ PRIVATE
     MoveList moves;
     unsigned int moveCnt;
     Result result;
+    size_t currentHash;
 
+    static size_t zobristTable[BOARD_SIZE + 2][BOARD_SIZE + 2][NUM_PIECE_TYPES];
+    static bool zobristInitialized;
+
+    static void initializeZobristTable();
+    int getPieceIndex(Piece piece);
+
+    void clearPattern(Cell& cell);
+    void setPatterns(Pos& p);
+    void setResult(Pos& p);
     Line getLine(Pos& p);
     Pattern getPattern(Line& line, Color color);
-    void setPatterns(Pos& p);
-    void clearPattern(Cell& cell);
-    void setResult(Pos& p);
 
 PUBLIC
     Board();
@@ -36,19 +45,31 @@ PUBLIC
     Result getResult();
     bool isForbidden(Pos p);
     vector<Pos> getPath();
+    size_t getCurrentHash() const;
     
 };
 
+size_t Board::zobristTable[BOARD_SIZE + 2][BOARD_SIZE + 2][NUM_PIECE_TYPES];
+bool Board::zobristInitialized = false;
+
 Board::Board() {
+    if (!zobristInitialized) {
+        initializeZobristTable();
+        zobristInitialized = true;
+    }
+    currentHash = 0;
     moveCnt = 0;
     result = ONGOING;
 
     for (int i = 0; i < BOARD_SIZE + 2; i++) {
         for (int j = 0; j < BOARD_SIZE + 2; j++) {
-            if (i == 0 || i == BOARD_SIZE + 1 || j == 0 || j == BOARD_SIZE + 1)
+            if (i == 0 || i == BOARD_SIZE + 1 || j == 0 || j == BOARD_SIZE + 1) {
                 cells[i][j].setPiece(WALL);
-            else
+                int pieceIndex = getPieceIndex(WALL);
+                currentHash ^= zobristTable[i][j][pieceIndex];
+            } else {
                 cells[i][j].setPiece(EMPTY);
+            }
         }
     }
 }
@@ -65,17 +86,14 @@ Cell& Board::getCell(const Pos p) {
     return cells[p.x][p.y];
 }
 
-void Board::clearPattern(Cell& cell) {
-    for(Direction dir = DIRECTION_START; dir < DIRECTION_SIZE; dir++) {
-        cell.setPattern(BLACK, dir, PATTERN_SIZE);
-        cell.setPattern(WHITE, dir, PATTERN_SIZE);
-    }
-}
-
 bool Board::move(Pos p) {
     if (getCell(p).getPiece() != EMPTY) return false;
     if (result != ONGOING) return false;
     if (moveCnt == BOARD_SIZE * BOARD_SIZE) return false;
+
+    Piece piece = isBlackTurn() ? BLACK : WHITE;
+    int pieceIndex = getPieceIndex(piece);
+    currentHash ^= zobristTable[p.x][p.y][pieceIndex];
 
     moveCnt++;
     moves.push_back(p);
@@ -86,6 +104,120 @@ bool Board::move(Pos p) {
     setPatterns(p);
 
     return true;
+}
+
+void Board::undo() {
+    if (moves.empty()) return;
+    Pos p = moves.back();
+
+    Piece piece = getCell(p).getPiece();
+    int pieceIndex = getPieceIndex(piece);
+    currentHash ^= zobristTable[p.x][p.y][pieceIndex];
+
+
+    moveCnt--;
+    getCell(p).setPiece(EMPTY);
+    setPatterns(p);
+    result = ONGOING;
+
+    moves.pop_back();
+}
+
+Result Board::getResult() {
+    return result;
+}
+
+bool Board::isForbidden(Pos p) {
+    Cell c = getCell(p);
+    if (c.getPiece() != EMPTY) return false;
+
+    int winByFour = 0;
+    int winByThree = 0;
+    int pThreeCnt = 0;
+
+    // five, overline, 4-4
+    for (Direction dir = DIRECTION_START; dir < DIRECTION_SIZE; dir++) {
+        p.dir = dir;
+        Pattern pattern = c.getPattern(BLACK, p.dir);
+        if (pattern == FIVE)
+            return false;
+        else if (pattern == OVERLINE)
+            return true;
+        else if (pattern == BLOCKED_4 || pattern == FREE_4) {
+            if (++winByFour >= 2)
+                return true;
+        }
+
+        if (pattern == FREE_3 || pattern == FREE_3A)
+            pThreeCnt++;
+    }
+    
+    // if there is not open three more than two
+    if (pThreeCnt < 2)
+        return false;
+
+    // recursive 3-3
+    // move
+    getCell(p).setPiece(BLACK);
+    setPatterns(p);
+
+    for (Direction dir = DIRECTION_START; dir < DIRECTION_SIZE; dir++) {
+        p.dir = dir;
+        Pattern pattern = c.getPattern(BLACK, p.dir);
+
+        // double three forbidden type
+        if (pattern != FREE_3 && pattern != FREE_3A)
+            continue;
+        
+        Pos posi = p;
+        for (int i = 0; i < LINE_LENGTH; i++) {
+            if (!(posi + (i - (LINE_LENGTH / 2))))
+                continue;
+
+            Cell &c = getCell(posi);
+            if (c.getPiece() == EMPTY) {
+                bool isFive = false;
+                if (c.getPattern(BLACK, dir) == FREE_4 && !isForbidden(posi)) {
+                    for (Direction eDir = DIRECTION_START; eDir < DIRECTION_SIZE; eDir++) {
+                        Pattern pattern = c.getPattern(BLACK, eDir);
+                        if (pattern == FIVE)
+                            isFive = true;
+                    }
+                    // made 5 with an empty space -> not a forbidden position
+                    if (!isFive) {
+                        winByThree++;
+                        break;
+                    }
+                }
+            }
+            posi - (i - (LINE_LENGTH / 2));
+        }
+
+        if (winByThree >= 2) {
+            break;
+        }
+    }
+
+    // undo
+    getCell(p).setPiece(EMPTY);
+    setPatterns(p);
+
+    return winByThree >= 2;
+}
+
+vector<Pos> Board::getPath() {
+    return moves;
+}
+
+size_t Board::getCurrentHash() const {
+    return currentHash;
+}
+
+void Board::clearPattern(Cell& cell) {
+    for(Direction dir = DIRECTION_START; dir < DIRECTION_SIZE; dir++) {
+        cell.setPattern(BLACK, dir, PATTERN_SIZE);
+        cell.setPattern(WHITE, dir, PATTERN_SIZE);
+    }
 }
 
 void Board::setPatterns(Pos& p) {
@@ -189,95 +321,6 @@ Pattern Board::getPattern(Line& line, Color color) {
     return p;
 }
 
-void Board::undo() {
-    Pos p = moves.back();
-
-    moveCnt--;
-    getCell(p).setPiece(EMPTY);
-    setPatterns(p);
-    result = ONGOING;
-
-    moves.pop_back();
-}
-
-bool Board::isForbidden(Pos p) {
-    Cell c = getCell(p);
-    if (c.getPiece() != EMPTY) return false;
-
-    int winByFour = 0;
-    int winByThree = 0;
-    int pThreeCnt = 0;
-
-    // five, overline, 4-4
-    for (Direction dir = DIRECTION_START; dir < DIRECTION_SIZE; dir++) {
-        p.dir = dir;
-        Pattern pattern = c.getPattern(BLACK, p.dir);
-        if (pattern == FIVE)
-            return false;
-        else if (pattern == OVERLINE)
-            return true;
-        else if (pattern == BLOCKED_4 || pattern == FREE_4) {
-            if (++winByFour >= 2)
-                return true;
-        }
-
-        if (pattern == FREE_3 || pattern == FREE_3A)
-            pThreeCnt++;
-    }
-    
-    // if there is not open three more than two
-    if (pThreeCnt < 2)
-        return false;
-
-    // recursive 3-3
-    // move
-    getCell(p).setPiece(BLACK);
-    setPatterns(p);
-
-    for (Direction dir = DIRECTION_START; dir < DIRECTION_SIZE; dir++) {
-        p.dir = dir;
-        Pattern pattern = c.getPattern(BLACK, p.dir);
-
-        // double three forbidden type
-        if (pattern != FREE_3 && pattern != FREE_3A)
-            continue;
-        
-        Pos posi = p;
-        for (int i = 0; i < LINE_LENGTH; i++) {
-            if (!(posi + (i - (LINE_LENGTH / 2))))
-                continue;
-
-            Cell &c = getCell(posi);
-            if (c.getPiece() == EMPTY) {
-                bool isFive = false;
-                if (c.getPattern(BLACK, dir) == FREE_4 && !isForbidden(posi)) {
-                    for (Direction eDir = DIRECTION_START; eDir < DIRECTION_SIZE; eDir++) {
-                        Pattern pattern = c.getPattern(BLACK, eDir);
-                        if (pattern == FIVE)
-                            isFive = true;
-                    }
-                    // made 5 with an empty space -> not a forbidden position
-                    if (!isFive) {
-                        winByThree++;
-                        break;
-                    }
-                }
-            }
-            posi - (i - (LINE_LENGTH / 2));
-        }
-
-        if (winByThree >= 2) {
-            break;
-        }
-    }
-
-    // undo
-    getCell(p).setPiece(EMPTY);
-    setPatterns(p);
-
-    return winByThree >= 2;
-}
-
 void Board::setResult(Pos& p) {
     bool isBlackTurn = this->isBlackTurn();
 
@@ -297,10 +340,31 @@ void Board::setResult(Pos& p) {
     result = ONGOING;
 }
 
-Result Board::getResult() {
-    return result;
+void Board::initializeZobristTable() {
+    random_device rd;
+    mt19937_64 rng(rd());
+    uniform_int_distribution<size_t> dist(0, numeric_limits<size_t>::max());
+
+    for (int i = 0; i <= BOARD_SIZE + 1; ++i) {
+        for (int j = 0; j <= BOARD_SIZE + 1; ++j) {
+            for (int k = 0; k < NUM_PIECE_TYPES; ++k) {
+                zobristTable[i][j][k] = dist(rng);
+            }
+        }
+    }
 }
 
-vector<Pos> Board::getPath() {
-    return moves;
+int Board::getPieceIndex(Piece piece) {
+    switch (piece) {
+        case EMPTY:
+            return 0;
+        case BLACK:
+            return 1;
+        case WHITE:
+            return 2;
+        case WALL:
+            return 3;
+        default:
+            return 0;
+    }
 }

--- a/test/unit_test/tree_manager_test.cpp
+++ b/test/unit_test/tree_manager_test.cpp
@@ -31,7 +31,7 @@ public:
         // registerTestMethod([this]() { testGenKey(); });
 
         // registerTestMethod([this]() { zobristHashUpdateTest(); });
-        // registerTestMethod([this]() { zobristHashConsistencyTest(); });
+        registerTestMethod([this]() { zobristHashConsistencyTest(); });
         // registerTestMethod([this]() { zobristHashAfterUndoTest(); });
         registerTestMethod([this]() { zobristHashCollisionTest(); });
     }
@@ -278,11 +278,17 @@ public:
         Board board1;
         Board board2;
 
-        string moves = "h8h9i8i9j8j9k8k9";
-        vector<pair<int, int>> v = processString(moves);
+        string moves1 = "h8h9i8i9j8j9k8k9";
+        vector<pair<int, int>> v1 = processString(moves1);
 
-        for (auto p : v) {
+        for (auto p : v1) {
             board1.move(Pos(p.first, p.second));
+        }
+
+        string moves2 = "j8j9k8k9h8h9i8i9";
+        vector<pair<int, int>> v2 = processString(moves2);
+
+        for (auto p : v2) {
             board2.move(Pos(p.first, p.second));
         }
 

--- a/tree/tree.h
+++ b/tree/tree.h
@@ -29,12 +29,7 @@ namespace std {
 class Tree {
 
 private:
-    unordered_map<size_t, shared_ptr<Node>> nodeMap; // Hash map to store nodes with board state keys.
-
-    static size_t zobristTable[BOARD_SIZE + 2][BOARD_SIZE + 2][NUM_PIECE_TYPES];
-    static bool zobristInitialized;
-
-    static void initializeZobristTable();
+    unordered_map<size_t, shared_ptr<Node>> nodeMap;
 
 public:
     Tree();
@@ -53,66 +48,11 @@ public:
 
 };
 
-size_t Tree::zobristTable[BOARD_SIZE + 2][BOARD_SIZE + 2][NUM_PIECE_TYPES];
-bool Tree::zobristInitialized = false;
-
-Tree::Tree() {
-    if (!zobristInitialized) {
-        initializeZobristTable();
-        zobristInitialized = true;
-    }
-}
-
-void Tree::initializeZobristTable() {
-    random_device rd;
-    mt19937_64 rng(rd());
-    uniform_int_distribution<size_t> dist(0, numeric_limits<size_t>::max());
-
-    for (int i = 0; i <= BOARD_SIZE + 1; ++i) {
-        for (int j = 0; j <= BOARD_SIZE + 1; ++j) {
-            for (int k = 0; k < NUM_PIECE_TYPES; ++k) {
-                zobristTable[i][j][k] = dist(rng);
-            }
-        }
-    }
-}
+Tree::Tree() { }
 
 // Definition of the generateKey method.
 size_t Tree::generateKey(Board& board) {
-    size_t hashValue = 0;
-
-    auto& cells = board.getBoardStatus();
-
-    for (int i = 0; i <= BOARD_SIZE + 1; ++i) {
-        for (int j = 0; j <= BOARD_SIZE + 1; ++j) {
-            Piece piece = cells[i][j].getPiece();
-
-            int pieceIndex = 0;
-
-            switch (piece) {
-                case EMPTY:
-                    pieceIndex = 0;
-                    break;
-                case BLACK:
-                    pieceIndex = 1;
-                    break;
-                case WHITE:
-                    pieceIndex = 2;
-                    break;
-                case WALL:
-                    pieceIndex = 3;
-                    break;
-                default:
-                    pieceIndex = 0;
-            }
-
-            if (piece != EMPTY) {
-                hashValue ^= zobristTable[i][j][pieceIndex];
-            }
-        }
-    }
-
-    return hashValue;
+    return board.getCurrentHash();
 }
 
 // Definition of the addNode method.


### PR DESCRIPTION
## Commit 1

feat: add Zobrist hashing

---
## Commit 2

fix: improve hash management and testing for Board class

### 추가된 것

* `tree_manager_test.cpp`에 Zobrist 해시 관련 테스트 메소드 추가:

    - `zobristHashUpdateTest`: 착수 시 해시 값이 올바르게 갱신되는지 검증.

    - `zobristHashConsistencyTest`: 동일한 보드 상태에서 동일한 해시 값을 가지는지 확인.

    - `zobristHashAfterUndoTest`: 착수 취소 후, 해시 값이 이전 상태로 정확히 복원되는지 확인.

    - `zobristHashCollisionTest`: 무작위로 생성된 10000개의 보드 상황에서, 충돌하는 해시 값의 개수 확인. (약 2분 소요)

### 변경된 것

* **Zobrist 테이블 관리 및 해시 계산 로직을 `Board` 클래스에서 관리하도록 변경.**

	- `Board` 클래스가 게임 전반의 상태를 관할하며, move와 undo를 담당하기 때문에, `Board` 내에서 해시를 업데이트하는 것이 데이터의 일관성 유지에 더 적합하다고 판단했기 때문.

	- `Tree` 클래스의 `generateKey` 메소드는, `Board` 클래스의 `currentHash`를 반환하도록 단순화.

	- 그 외에 `Tree` 클래스에서 담당하던 해시 관련 코드를 모두 `Board`로 이동.

	- `Board` 클래스의 `move` 및 `undo` 메소드가 보드 상태와 동기화된 Zobrist 해시를 즉각 갱신하도록 수정:

    		1. `move` 메소드: 착수 시 Zobrist 해시 값이 업데이트되도록 변경.

    		2. `undo` 메소드: 착수 취소 시 Zobrist 해시 값이 이전 상태로 복원되도록 변경.

* 가독성 위해,`Board` 클래스 메소드 순서 일부 조정.

### 유의 사항 및 질문 사항

* 테스트 케이스 검토 및 추가 요망.

* Zobrist 테이블 초기화 시 난수 생성의 목적은, 해시 값을 해시 공간에서 균등하게 분포하게 하여, 동일한 해시 값을 생성할 확률을 최소화하기 위함임. 보안 문제와는 크게 관련 없음.

* 해싱 충돌 상황이 10000개당 10~20개 꼴로 발생함. 계속해서 개선할 예정.

---
## Commit 3, 4

fix: modify testing error

### 변경된 것

* 해싱 충돌 테스트 시, 중복 상황 제거. 해싱 충돌이 없음을 확인.