### PR TITLE
Zobrist Hash 구현 리팩토링 

### DIFF
--- a/game/board.h
+++ b/game/board.h
@@ -2,14 +2,13 @@
 
 #include "line.h"
 #include "pos.h"
+#include "zobrist.h"
 #include "../test/test.h"
 #include <array>
 #include <vector>
-#include <random>
 
 #define BOARD_SIZE 15
 #define STATIC_WALL &cells[0][0];
-#define NUM_PIECE_TYPES 4
 
 using CellArray = array<array<Cell, BOARD_SIZE + 2>, BOARD_SIZE + 2>;
 using MoveList = vector<Pos>;
@@ -22,10 +21,6 @@ PRIVATE
     unsigned int moveCnt;
     Result result;
     size_t currentHash;
-
-    static size_t zobristTable[BOARD_SIZE + 2][BOARD_SIZE + 2][NUM_PIECE_TYPES];
-    static bool zobristInitialized;
-    static void initializeZobristTable();
 
     void clearPattern(Cell& cell);
     void setPatterns(Pos& p);
@@ -47,14 +42,7 @@ PUBLIC
     
 };
 
-size_t Board::zobristTable[BOARD_SIZE + 2][BOARD_SIZE + 2][NUM_PIECE_TYPES];
-bool Board::zobristInitialized = false;
-
 Board::Board() {
-    if (!zobristInitialized) {
-        initializeZobristTable();
-        zobristInitialized = true;
-    }
     currentHash = 0;
     moveCnt = 0;
     result = ONGOING;
@@ -63,7 +51,7 @@ Board::Board() {
         for (int j = 0; j < BOARD_SIZE + 2; j++) {
             if (i == 0 || i == BOARD_SIZE + 1 || j == 0 || j == BOARD_SIZE + 1) {
                 cells[i][j].setPiece(WALL);
-                currentHash ^= zobristTable[i][j][WALL];
+                currentHash ^= getZobristValue(i, j, WALL);
             } else {
                 cells[i][j].setPiece(EMPTY);
             }
@@ -88,15 +76,14 @@ bool Board::move(Pos p) {
     if (result != ONGOING) return false;
     if (moveCnt == BOARD_SIZE * BOARD_SIZE) return false;
 
-    Piece piece = isBlackTurn() ? BLACK : WHITE;
-    currentHash ^= zobristTable[p.x][p.y][piece];
-
-    getCell(p).setPiece(piece);
-
     moveCnt++;
     moves.push_back(p);
-    
+
     setResult(p);
+
+    Piece piece = isBlackTurn() ? WHITE : BLACK;
+    currentHash ^= getZobristValue(p.x, p.y, piece);
+    getCell(p).setPiece(piece);
 
     clearPattern(getCell(p));
     setPatterns(p);
@@ -109,7 +96,7 @@ void Board::undo() {
     Pos p = moves.back();
 
     Piece piece = getCell(p).getPiece();
-    currentHash ^= zobristTable[p.x][p.y][piece];
+    currentHash ^= getZobristValue(p.x, p.y, piece);
     
     getCell(p).setPiece(EMPTY);
 
@@ -320,38 +307,20 @@ Pattern Board::getPattern(Line& line, Color color) {
 }
 
 void Board::setResult(Pos& p) {
-    Piece self = getCell(p).getPiece();
+    bool isBlackTurn = this->isBlackTurn();
 
-    if (self == EMPTY) {
-        result = ONGOING;
-        return;
-    }
-
-    if (self == BLACK && isForbidden(p)) {
+    if (!isBlackTurn && isForbidden(p)) {
         result = WHITE_WIN;
         return;
     }
 
+    Piece self = isBlackTurn ? WHITE : BLACK;
     for (Direction dir = DIRECTION_START; dir < DIRECTION_SIZE; dir++) {
-        if (getCell(p).getPattern(self, dir) == FIVE) {
-            result = (self == BLACK) ? BLACK_WIN : WHITE_WIN;
+        if(getCell(p).getPattern(self, dir) == FIVE) {
+            result = isBlackTurn ? WHITE_WIN : BLACK_WIN;
             return;
         }
     }
 
     result = ONGOING;
-}
-
-void Board::initializeZobristTable() {
-    random_device rd;
-    mt19937_64 rng(rd());
-    uniform_int_distribution<size_t> dist(0, numeric_limits<size_t>::max());
-
-    for (int i = 0; i <= BOARD_SIZE + 1; ++i) {
-        for (int j = 0; j <= BOARD_SIZE + 1; ++j) {
-            for (int k = 0; k < NUM_PIECE_TYPES; ++k) {
-                zobristTable[i][j][k] = dist(rng);
-            }
-        }
-    }
 }

--- a/game/board.h
+++ b/game/board.h
@@ -25,9 +25,7 @@ PRIVATE
 
     static size_t zobristTable[BOARD_SIZE + 2][BOARD_SIZE + 2][NUM_PIECE_TYPES];
     static bool zobristInitialized;
-
     static void initializeZobristTable();
-    int getPieceIndex(Piece piece);
 
     void clearPattern(Cell& cell);
     void setPatterns(Pos& p);
@@ -65,8 +63,7 @@ Board::Board() {
         for (int j = 0; j < BOARD_SIZE + 2; j++) {
             if (i == 0 || i == BOARD_SIZE + 1 || j == 0 || j == BOARD_SIZE + 1) {
                 cells[i][j].setPiece(WALL);
-                int pieceIndex = getPieceIndex(WALL);
-                currentHash ^= zobristTable[i][j][pieceIndex];
+                currentHash ^= zobristTable[i][j][WALL];
             } else {
                 cells[i][j].setPiece(EMPTY);
             }
@@ -92,9 +89,7 @@ bool Board::move(Pos p) {
     if (moveCnt == BOARD_SIZE * BOARD_SIZE) return false;
 
     Piece piece = isBlackTurn() ? BLACK : WHITE;
-    int pieceIndex = getPieceIndex(piece);
-
-    currentHash ^= zobristTable[p.x][p.y][pieceIndex];
+    currentHash ^= zobristTable[p.x][p.y][piece];
 
     getCell(p).setPiece(piece);
 
@@ -114,9 +109,7 @@ void Board::undo() {
     Pos p = moves.back();
 
     Piece piece = getCell(p).getPiece();
-    int pieceIndex = getPieceIndex(piece);
-
-    currentHash ^= zobristTable[p.x][p.y][pieceIndex];
+    currentHash ^= zobristTable[p.x][p.y][piece];
     
     getCell(p).setPiece(EMPTY);
 
@@ -360,20 +353,5 @@ void Board::initializeZobristTable() {
                 zobristTable[i][j][k] = dist(rng);
             }
         }
-    }
-}
-
-int Board::getPieceIndex(Piece piece) {
-    switch (piece) {
-        case EMPTY:
-            return 0;
-        case BLACK:
-            return 1;
-        case WHITE:
-            return 2;
-        case WALL:
-            return 3;
-        default:
-            return 0;
     }
 }

--- a/game/zobrist.h
+++ b/game/zobrist.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "board.h"
+#include <random>
+
+#define NUM_PIECE_TYPES 4
+
+static size_t zobristTable[BOARD_SIZE + 2][BOARD_SIZE + 2][NUM_PIECE_TYPES];
+static bool zobristInitialized = false;
+
+static void initializeZobristTable() {
+    random_device rd;
+    mt19937_64 rng(rd());
+    uniform_int_distribution<size_t> dist(0, numeric_limits<size_t>::max());
+
+    for (int i = 0; i <= BOARD_SIZE + 1; ++i) {
+        for (int j = 0; j <= BOARD_SIZE + 1; ++j) {
+            for (int k = 0; k < NUM_PIECE_TYPES; ++k) {
+                zobristTable[i][j][k] = dist(rng);
+            }
+        }
+    }
+}
+
+static size_t getZobristValue(int x, int y, Piece piece) {
+    if(!zobristInitialized) {
+        initializeZobristTable();
+        zobristInitialized = true;
+    }
+
+    return zobristTable[x][y][piece];
+}

--- a/game/zobrist.h
+++ b/game/zobrist.h
@@ -2,16 +2,17 @@
 
 #include "board.h"
 #include <random>
+#include <mutex>
 
 #define NUM_PIECE_TYPES 4
 
 static size_t zobristTable[BOARD_SIZE + 2][BOARD_SIZE + 2][NUM_PIECE_TYPES];
-static bool zobristInitialized = false;
+static std::once_flag zobristInitFlag;
 
 static void initializeZobristTable() {
-    random_device rd;
-    mt19937_64 rng(rd());
-    uniform_int_distribution<size_t> dist(0, numeric_limits<size_t>::max());
+    std::random_device rd;
+    std::mt19937_64 rng(rd());
+    std::uniform_int_distribution<size_t> dist(0, std::numeric_limits<size_t>::max());
 
     for (int i = 0; i <= BOARD_SIZE + 1; ++i) {
         for (int j = 0; j <= BOARD_SIZE + 1; ++j) {
@@ -23,10 +24,6 @@ static void initializeZobristTable() {
 }
 
 static size_t getZobristValue(int x, int y, Piece piece) {
-    if(!zobristInitialized) {
-        initializeZobristTable();
-        zobristInitialized = true;
-    }
-
+    std::call_once(zobristInitFlag, initializeZobristTable);
     return zobristTable[x][y][piece];
 }

--- a/test/unit_test/tree_manager_test.cpp
+++ b/test/unit_test/tree_manager_test.cpp
@@ -30,10 +30,10 @@ public:
         // registerTestMethod([this]() { sequentialMovePathTest(); });
         // registerTestMethod([this]() { testGenKey(); });
 
-        // registerTestMethod([this]() { zobristHashUpdateTest(); });
+        registerTestMethod([this]() { zobristHashUpdateTest(); });
         registerTestMethod([this]() { zobristHashConsistencyTest(); });
-        // registerTestMethod([this]() { zobristHashAfterUndoTest(); });
-        registerTestMethod([this]() { zobristHashCollisionTest(); });
+        registerTestMethod([this]() { zobristHashAfterUndoTest(); });
+        // registerTestMethod([this]() { zobristHashCollisionTest(); });
     }
 
     void rootNodeInitializationTest() {
@@ -263,8 +263,7 @@ public:
 
         TEST_ASSERT(initialHash != hashAfterMove);
 
-        int pieceIndex = board.getPieceIndex(BLACK);
-        size_t expectedHash = initialHash ^ Board::zobristTable[movePos.getX()][movePos.getY()][pieceIndex];
+        size_t expectedHash = initialHash ^ getZobristValue(movePos.getX(), movePos.getY(), BLACK);
         TEST_PRINT("Expected Hash after move: " << expectedHash);
 
         TEST_ASSERT(hashAfterMove == expectedHash);


### PR DESCRIPTION
### 작업 내용
- 기존 Zobrist Hash 구현 코드를 따로 zobrist.h로 빼고 관리하도록 수정 (board.h에 과한 치중을 경감) 
- getIndex라는 Piece의 인덱스를 반환하는 함수 삭제(Enum Piece에 종속성이 과해진다고 판단) -> Piece는 Enum이라 자체적으로 int로 형 변환하여 사용가능
- zobrist hash를 작업하면서 move 함수의 setResult 함수 호출 순서를 바꾸면서 생긴 버그 해결
- zobrist 관련 코드 thread safe 하도록 수정 (std::mutex를 활용하려면 mingw 버전 업데이트 필요. 노션 AI/Research 참고)