### PR TITLE
NWS 적용

### DIFF
--- a/evaluate/value.h
+++ b/evaluate/value.h
@@ -72,6 +72,10 @@ PUBLIC
         return resultDepth;
     }
 
+    bool isOnGoing() {
+        return result == Result::ONGOING;
+    }
+
     void setType(Type type) {
         this->type = type;
     }

--- a/search/search.h
+++ b/search/search.h
@@ -67,7 +67,8 @@ Value Search::abp(int depth) {
         // if already searched
         if (currentNode->searchedDepth >= cur.depth && 
             currentNode->value.getValue() != INITIAL_VALUE && 
-            currentNode->value.getType() != Value::Type::UNKNOWN) {
+            currentNode->value.getType() != Value::Type::UNKNOWN && 
+            cur.childIdx == 0) {
             Value cv = currentNode->value;
             bool cut = false;
 
@@ -148,8 +149,7 @@ Value Search::abp(int depth) {
                 cur.bestVal = cur.isMax ? cur.alpha : cur.beta;
                 cur.bestVal.setType(cur.isMax ? Value::Type::UPPER_BOUND : Value::Type::LOWER_BOUND);
             }
-            if (cur.searchMode == SearchMode::FULL_WINDOW)
-                currentNode->searchedDepth = cur.depth;
+            currentNode->searchedDepth = cur.depth;
             currentNode->value = cur.bestVal;
             
             treeManager.undo();
@@ -209,8 +209,7 @@ void Search::updateParent(stack<ABPNode>& stk, Value childValue, SearchMode chil
     if (parent.beta <= parent.alpha) {
         // pruning
         parentNode->value.setType(parent.isMax ? Value::Type::LOWER_BOUND : Value::Type::UPPER_BOUND);
-        if (parent.searchMode == SearchMode::FULL_WINDOW)
-            parentNode->searchedDepth = parent.depth;
+        parentNode->searchedDepth = parent.depth;
 
         treeManager.undo();
         stk.pop();

--- a/search/search.h
+++ b/search/search.h
@@ -74,10 +74,8 @@ Value Search::abp(int depth) {
                 cut = true;
             } else if (currentNode->value.getType() == Value::Type::LOWER_BOUND) {
                 if (cv >= cur.beta) cut = true;
-                else cur.alpha = cur.alpha > cv ? cur.alpha : cv;
             } else if (currentNode->value.getType() == Value::Type::UPPER_BOUND) {
                 if (cv <= cur.alpha) cut = true;
-                else cur.beta = cur.beta < cv ? cur.beta : cv;
             }
 
             if (cut) {

--- a/search/search.h
+++ b/search/search.h
@@ -187,22 +187,26 @@ void Search::updateParent(stack<ABPNode>& stk, Value childValue, SearchMode chil
     }
 
     if (parent.isMax) {
-        if (childValue > parent.bestVal && childValue.getType() == Value::Type::EXACT) {
+        if (childValue > parent.bestVal && (childValue.getType() == Value::Type::EXACT || childValue.getType() == Value::Type::LOWER_BOUND)) {
             parent.bestVal = childValue;
             parentNode->value = childValue;
             parentNode->bestMove = lastMove;
         }
-        if (childValue > parent.alpha) {
-            parent.alpha = childValue;
+        if (childValue.getType() == Value::Type::EXACT || childValue.getType() == Value::Type::LOWER_BOUND) {
+            if (childValue > parent.alpha) {
+                parent.alpha = childValue;
+            }
         }
     } else {
-        if (childValue < parent.bestVal && childValue.getType() == Value::Type::EXACT) {
+        if (childValue < parent.bestVal && (childValue.getType() == Value::Type::EXACT || childValue.getType() == Value::Type::UPPER_BOUND)) {
             parent.bestVal = childValue;
             parentNode->value = childValue;
             parentNode->bestMove = lastMove;
         }
-        if (childValue < parent.beta) {
-            parent.beta = childValue;
+        if (childValue.getType() == Value::Type::EXACT || childValue.getType() == Value::Type::UPPER_BOUND) {
+            if (childValue < parent.beta) {
+                parent.beta = childValue;
+            }
         }
     }
 
@@ -217,8 +221,7 @@ void Search::updateParent(stack<ABPNode>& stk, Value childValue, SearchMode chil
 }
 
 Value Search::evaluateNode(Evaluator& evaluator) {
-    treeManager.getNode()->value = evaluator.evaluate();
-    return treeManager.getNode()->value;
+    return evaluator.evaluate();
 }
 
 MoveList Search::getCandidates(Evaluator& evaluator, bool isMax) {
@@ -281,6 +284,7 @@ void Search::ids() {
 
         if (result.isWin() && result.getResultDepth() <= monitor.getDepth()) 
             break;
+
         monitor.incDepth(2);
     }
 }

--- a/search/search.h
+++ b/search/search.h
@@ -148,7 +148,8 @@ Value Search::abp(int depth) {
                 cur.bestVal = cur.isMax ? cur.alpha : cur.beta;
                 cur.bestVal.setType(cur.isMax ? Value::Type::UPPER_BOUND : Value::Type::LOWER_BOUND);
             }
-            currentNode->searchedDepth = cur.depth;
+            if (cur.searchMode == SearchMode::FULL_WINDOW)
+                currentNode->searchedDepth = cur.depth;
             currentNode->value = cur.bestVal;
             
             treeManager.undo();
@@ -208,7 +209,8 @@ void Search::updateParent(stack<ABPNode>& stk, Value childValue, SearchMode chil
     if (parent.beta <= parent.alpha) {
         // pruning
         parentNode->value.setType(parent.isMax ? Value::Type::LOWER_BOUND : Value::Type::UPPER_BOUND);
-        parentNode->searchedDepth = parent.depth;
+        if (parent.searchMode == SearchMode::FULL_WINDOW)
+            parentNode->searchedDepth = parent.depth;
 
         treeManager.undo();
         stk.pop();

--- a/search/search.h
+++ b/search/search.h
@@ -187,32 +187,32 @@ void Search::updateParent(stack<ABPNode>& stk, Value childValue, SearchMode chil
     }
 
     if (parent.isMax) {
-        if (childValue > parent.bestVal && (childValue.getType() == Value::Type::EXACT || childValue.getType() == Value::Type::LOWER_BOUND)) {
+        if (childValue > parent.bestVal && childValue.getType() == Value::Type::EXACT) {
             parent.bestVal = childValue;
             parentNode->value = childValue;
             parentNode->bestMove = lastMove;
         }
-        if (childValue.getType() == Value::Type::EXACT || childValue.getType() == Value::Type::LOWER_BOUND) {
-            if (childValue > parent.alpha) {
-                parent.alpha = childValue;
-            }
+        if (childValue > parent.alpha) {
+            parent.alpha = childValue;
         }
     } else {
-        if (childValue < parent.bestVal && (childValue.getType() == Value::Type::EXACT || childValue.getType() == Value::Type::UPPER_BOUND)) {
+        if (childValue < parent.bestVal && childValue.getType() == Value::Type::EXACT) {
             parent.bestVal = childValue;
             parentNode->value = childValue;
             parentNode->bestMove = lastMove;
         }
-        if (childValue.getType() == Value::Type::EXACT || childValue.getType() == Value::Type::UPPER_BOUND) {
-            if (childValue < parent.beta) {
-                parent.beta = childValue;
-            }
+        if (childValue < parent.beta) {
+            parent.beta = childValue;
         }
     }
 
     if (parent.beta <= parent.alpha) {
         // pruning
-        parentNode->value.setType(parent.isMax ? Value::Type::LOWER_BOUND : Value::Type::UPPER_BOUND);
+        if (parent.bestVal.getType() == Value::Type::UNKNOWN) {
+            parentNode->value = Value();
+        } else {
+            parentNode->value.setType(parent.isMax ? Value::Type::LOWER_BOUND : Value::Type::UPPER_BOUND);
+        }
         parentNode->searchedDepth = parent.depth;
 
         treeManager.undo();

--- a/search/search.h
+++ b/search/search.h
@@ -9,6 +9,11 @@
 #include <limits>
 #include <stack>
 
+enum class SearchMode {
+    FULL_WINDOW,
+    NULL_WINDOW
+};
+
 struct ABPNode {
     int depth;
     bool isMax;
@@ -17,6 +22,7 @@ struct ABPNode {
     Value bestVal;
     int childIdx;
     MoveList childMoves;
+    SearchMode searchMode;
 };
 
 class Search {
@@ -30,7 +36,7 @@ PRIVATE
     Value evaluateNode(Evaluator& evaluator);
     MoveList getCandidates(Evaluator& evaluator, bool isMax);
     void sortChildNodes(MoveList& moves, bool isTarget);
-    void updateParent(stack<ABPNode>& stk, Value val);
+    void updateParent(stack<ABPNode>& stk, Value childValue, SearchMode childMode);
     bool isGameOver(Board& board);
 
 PUBLIC
@@ -48,7 +54,7 @@ Search::Search(Board& board, SearchMonitor& monitor) : treeManager(board), monit
 
 Value Search::abp(int depth) {
     stack<ABPNode> stk;
-    stk.push({depth, true, Value(MIN_VALUE, Value::Type::UNKNOWN), Value(MAX_VALUE + 1, Value::Type::UNKNOWN), Value(), {}});
+    stk.push(ABPNode{depth, true, Value(MIN_VALUE, Value::Type::UNKNOWN), Value(MAX_VALUE + 1, Value::Type::UNKNOWN), Value(), 0, {}, SearchMode::FULL_WINDOW});
 
     while (!stk.empty()) {
         monitor.updateElapsedTime();
@@ -76,7 +82,7 @@ Value Search::abp(int depth) {
                 stk.pop();
 
                 if (!stk.empty()) {
-                    updateParent(stk, cv);
+                    updateParent(stk, cv, cur.searchMode);
                 }
 
                 continue;
@@ -104,7 +110,7 @@ Value Search::abp(int depth) {
             stk.pop();
 
             if (!stk.empty()) {
-                updateParent(stk, val);
+                updateParent(stk, val, cur.searchMode);
             }
 
             continue;
@@ -113,11 +119,27 @@ Value Search::abp(int depth) {
         if (cur.childIdx < cur.childMoves.size()) {
             Pos move = cur.childMoves[cur.childIdx++];
             treeManager.move(move);
+
             Value nextAlpha = cur.alpha;
             Value nextBeta = cur.beta;
             nextAlpha.decreaseResultDepth();
             nextBeta.decreaseResultDepth();
-            stk.push({cur.depth - 1, !cur.isMax, nextAlpha, nextBeta, 0, {}});
+
+            if (cur.searchMode == SearchMode::NULL_WINDOW) { // null window search in progress
+                stk.push({cur.depth - 1, !cur.isMax, nextAlpha, nextBeta, Value(), 0, {}, SearchMode::NULL_WINDOW});
+            } else if (cur.childIdx > 1) { // start new null window search
+                if (cur.isMax) {
+                    nextBeta = nextAlpha;
+                    nextBeta += 1;
+                } else {
+                    nextAlpha = nextBeta;
+                    nextAlpha -= 1;
+                }
+                stk.push({cur.depth - 1, !cur.isMax, nextAlpha, nextBeta, Value(), 0, {}, SearchMode::NULL_WINDOW});
+            } else {
+                stk.push({cur.depth - 1, !cur.isMax, nextAlpha, nextBeta, Value(), 0, {}, SearchMode::FULL_WINDOW});
+            }
+            
             monitor.incVisitCnt();
         } else { // if search every child nodes
             if (cur.bestVal.getType() == Value::Type::UNKNOWN) {
@@ -131,7 +153,7 @@ Value Search::abp(int depth) {
             stk.pop();
 
             if (!stk.empty()) {
-                updateParent(stk, cur.bestVal);
+                updateParent(stk, cur.bestVal, cur.searchMode);
             }
         }
     }
@@ -139,32 +161,45 @@ Value Search::abp(int depth) {
     return treeManager.getNode()->value;
 }
 
-void Search::updateParent(stack<ABPNode>& stk, Value val) {
+void Search::updateParent(stack<ABPNode>& stk, Value childValue, SearchMode childMode) {
     ABPNode& parent = stk.top();
     Node* parentNode = treeManager.getNode();
     Pos lastMove;
     if (parent.childIdx > 0 && parent.childIdx - 1 < parent.childMoves.size()) {
         lastMove = parent.childMoves[parent.childIdx - 1];
     }
-    val.increaseResultDepth();
+    childValue.increaseResultDepth();
+
+    // if null window search failed, re-search with full window
+    if (parent.searchMode == SearchMode::FULL_WINDOW && childMode == SearchMode::NULL_WINDOW) {
+        Value nextAlpha = parent.alpha;
+        Value nextBeta = parent.beta;
+        nextAlpha.decreaseResultDepth();
+        nextBeta.decreaseResultDepth();
+
+        stk.push({parent.depth - 1, !parent.isMax, nextAlpha, nextBeta, Value(), 0, {}, SearchMode::FULL_WINDOW});
+        Pos move = parent.childMoves[parent.childIdx - 1];
+        treeManager.move(move);
+        return;
+    }
 
     if (parent.isMax) {
-        if (val > parent.bestVal && val.getType() == Value::Type::EXACT) {
-            parent.bestVal = val;
-            parentNode->value = val;
+        if (childValue > parent.bestVal && childValue.getType() == Value::Type::EXACT) {
+            parent.bestVal = childValue;
+            parentNode->value = childValue;
             parentNode->bestMove = lastMove;
         }
-        if (val > parent.alpha) {
-            parent.alpha = val;
+        if (childValue > parent.alpha) {
+            parent.alpha = childValue;
         }
     } else {
-        if (val < parent.bestVal && val.getType() == Value::Type::EXACT) {
-            parent.bestVal = val;
-            parentNode->value = val;
+        if (childValue < parent.bestVal && childValue.getType() == Value::Type::EXACT) {
+            parent.bestVal = childValue;
+            parentNode->value = childValue;
             parentNode->bestMove = lastMove;
         }
-        if (val < parent.beta) {
-            parent.beta = val;
+        if (childValue < parent.beta) {
+            parent.beta = childValue;
         }
     }
 

--- a/search/search.h
+++ b/search/search.h
@@ -50,6 +50,9 @@ Search::Search(Board& board, SearchMonitor& monitor) : treeManager(board), monit
     monitor.setBestLineProvider([this](int i) {
         return treeManager.getBestLine(i);
     });
+    monitor.setBestValueProvider([this]() {
+        return treeManager.getRootNode()->value;
+    });
 }
 
 Value Search::abp(int depth) {

--- a/search/search.h
+++ b/search/search.h
@@ -66,6 +66,7 @@ Value Search::abp(int depth) {
 
         // if already searched
         if (currentNode->searchedDepth >= cur.depth && 
+            currentNode->value.getValue() != INITIAL_VALUE && 
             currentNode->value.getType() != Value::Type::UNKNOWN) {
             Value cv = currentNode->value;
             bool cut = false;

--- a/search/search_monitor.h
+++ b/search/search_monitor.h
@@ -15,11 +15,13 @@ PRIVATE
     double elapsedTime;
     MoveList bestPath; // final best path determined after one complete search iteration
     MoveList bestLine; // best line, updated when getBestLine() is explicitly called
+    Value bestValue;
     int depth;
     size_t visitCnt;
     function<bool(SearchMonitor&)> trigger;
     function<void(SearchMonitor&)> searchListener;
     function<MoveList(int)> bestLineProvider;
+    function<Value()> bestValueProvider;
 
 PUBLIC
     SearchMonitor();
@@ -29,6 +31,7 @@ PUBLIC
     void setSearchListener(function<void(SearchMonitor&)> newSearchListener) { searchListener = newSearchListener; };
     void executeTrigger();
     void setBestLineProvider(std::function<MoveList(int)> provider) { bestLineProvider = provider; }
+    void setBestValueProvider(std::function<Value()> provider) { bestValueProvider = provider; }
     
     // update data function, executeTrigger function execute
     void updateElapsedTime();
@@ -43,6 +46,7 @@ PUBLIC
     size_t getVisitCnt() { return visitCnt; }
     MoveList getBestPath() { return bestPath; }
     MoveList getBestLine(int i) { return bestLineProvider ? bestLineProvider(i) : MoveList(); }
+    Value getBestValue() { return bestValueProvider ? bestValueProvider() : Value(); }
 
 };
 

--- a/test/unit_test/search_test.cpp
+++ b/test/unit_test/search_test.cpp
@@ -44,7 +44,8 @@ PUBLIC
         const string processArr[] = {
             "h8h9i8g8i10i9j9k10j7i7",
             "h8h9i8g8i10i9j9k8k10l11i7j6",
-            "h8h9j9g8j10g7i10"
+            "h8h9j9g8j10g7i10",
+            "h8h9f6g7e9g8f7h6f8f9h7d6"
         };
 
         for (auto process : processArr) {

--- a/test/unit_test/search_test.cpp
+++ b/test/unit_test/search_test.cpp
@@ -46,6 +46,8 @@ PUBLIC
             "h8h9i8g8i10i9j9k10j7i7",
             "h8h9i8g8i10i9j9k8k10l11i7j6",
             "h8h9j9g8j10g7i10",
+            "h8i9h9h10g9g8f8g7e7f7g6f6i6h6j5j6k7j8k9i10j10i11i12h11g11e8f9",
+            "h8i8i9i7j8j7j6k7k6i6h7h6i5g7f8h10i10d8f6",
             "h8h9f6g7e9g8f7h6f8f9h7d6"
         };
 

--- a/test/unit_test/search_test.cpp
+++ b/test/unit_test/search_test.cpp
@@ -43,12 +43,12 @@ PUBLIC
 
     void testAlphaBetaSearch() {
         const string processArr[] = {
-            "h8h9i8g8i10i9j9k10j7i7",
-            "h8h9i8g8i10i9j9k8k10l11i7j6",
-            "h8h9j9g8j10g7i10",
+            // "h8h9i8g8i10i9j9k10j7i7",
+            // "h8h9i8g8i10i9j9k8k10l11i7j6",
+            // "h8h9j9g8j10g7i10",
             "h8i9h9h10g9g8f8g7e7f7g6f6i6h6j5j6k7j8k9i10j10i11i12h11g11e8f9",
-            "h8i8i9i7j8j7j6k7k6i6h7h6i5g7f8h10i10d8f6",
-            "h8h9f6g7e9g8f7h6f8f9h7d6"
+            // "h8i8i9i7j8j7j6k7k6i6h7h6i5g7f8h10i10d8f6",
+            // "h8h9f6g7e9g8f7h6f8f9h7d6"
         };
 
         for (auto process : processArr) {

--- a/test/unit_test/search_test.cpp
+++ b/test/unit_test/search_test.cpp
@@ -43,12 +43,12 @@ PUBLIC
 
     void testAlphaBetaSearch() {
         const string processArr[] = {
-            // "h8h9i8g8i10i9j9k10j7i7",
-            // "h8h9i8g8i10i9j9k8k10l11i7j6",
-            // "h8h9j9g8j10g7i10",
+            "h8h9i8g8i10i9j9k10j7i7",
+            "h8h9i8g8i10i9j9k8k10l11i7j6",
+            "h8h9j9g8j10g7i10",
             "h8i9h9h10g9g8f8g7e7f7g6f6i6h6j5j6k7j8k9i10j10i11i12h11g11e8f9",
-            // "h8i8i9i7j8j7j6k7k6i6h7h6i5g7f8h10i10d8f6",
-            // "h8h9f6g7e9g8f7h6f8f9h7d6"
+            "h8i8i9i7j8j7j6k7k6i6h7h6i5g7f8h10i10d8f6",
+            "h8h9f6g7e9g8f7h6f8f9h7d6"
         };
 
         for (auto process : processArr) {

--- a/test/unit_test/search_test.cpp
+++ b/test/unit_test/search_test.cpp
@@ -22,7 +22,8 @@ PRIVATE
         });
 
         monitor.setSearchListener([&searcher](SearchMonitor& monitor) {
-            TEST_PRINT("Depth: " << monitor.getDepth() << ", Time: " << monitor.getElapsedTime() << "sec, Node: " << monitor.getVisitCnt());
+            TEST_PRINT("Depth: " << monitor.getDepth() << ", Time: " << monitor.getElapsedTime() << 
+            "sec, Node: " << monitor.getVisitCnt() << ", Value: " << monitor.getBestValue().getValue());
             printPath(monitor.getBestPath());
         });
 


### PR DESCRIPTION
## 개요
유망하지 않은 수들의 빠른 pruning을 위한 null window 적용

## 상세 설명
- 모든 child node는 유망한 순서대로 정렬될 수 있다는 부분을 이용함
- 가장 유망한 수는 정상적으로 ABP 탐색, 그렇지 않은 수는 빠른 pruning이 일어나도록 alpha, beta 값을 의도적으로 좁힘
- 좁힌 범위로 탐색할때 더 좋은 value 값을 결과로 도출할 수 있을 경우 다시 정상적인 ABP 탐색

## 기대 효과
- 유망하지 않은 노드들의 훨씬 빠른 pruning으로 깊이가 깊어질수록 기하급수적인 탐색 노드 감소를 기대

## 트러블 슈팅
- NWS로 인해 재탐색이 이루어지는 경우 동형 cut의 조건과 맞물려서 의도치 않은 cut이 일어나는 경우
-> 동형 cut의 조건에 '처음 방문하는 노드'일 경우만 cut하도록 수정
- NWS로 인해 ids의 이전 탐색의 value 값의 찌꺼기로 인한 의도치 않은 cut이 일어나는 경우
-> 현재 탐색에서 이전 탐색의 value 값의 찌꺼기를 없애도록 pruning하는 경우에 bestVal이 한번도 업데이트 되지 않았을 경우 value를 INITIAL_VALUE로 초기화